### PR TITLE
feat: integrate Ollama AI model with generate endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,11 @@
 # Directory where log files will be stored
 # Default: logs (relative to project root)
 LOGS_DIR=logs
+
+# Ollama AI Model Configuration
+# Base URL for Ollama API (required)
+OLLAMA_BASE_URL=http://localhost:11434
+
+# Default AI model to use (required)
+# Examples: llama3.2:1b, gemma2:2b, qwen2.5:1.5b
+OLLAMA_MODEL=llama3.2:1b

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ cp .env.example .env
 Edit `.env` to customize settings:
 
 - `LOGS_DIR`: Directory for log files (default: `logs`)
+- `OLLAMA_BASE_URL`: Base URL for Ollama API (required, example: `http://localhost:11434`)
+- `OLLAMA_MODEL`: Default AI model to use (required, example: `llama3.2:1b`)
 
 ### Logging System
 
@@ -83,13 +85,15 @@ Start the Ollama service using Docker:
 # Start Ollama in the background
 docker-compose up -d
 
-# Pull a lightweight model (recommended for Mac Mini M1)
+# Pull the model specified in your .env file (default: llama3.2:1b)
 docker exec -it offline-prompt-ollama ollama pull llama3.2:1b
 
-# Alternative models (choose one based on your needs):
+# Alternative models (choose one based on your needs and update OLLAMA_MODEL in .env):
 # docker exec -it offline-prompt-ollama ollama pull gemma2:2b  # 2GB model
 # docker exec -it offline-prompt-ollama ollama pull qwen2.5:1.5b  # 1.5GB model
 ```
+
+**Important**: Make sure to update your `.env` file with the correct `OLLAMA_MODEL` value matching the model you pulled.
 
 Verify Ollama is running:
 
@@ -97,7 +101,7 @@ Verify Ollama is running:
 curl http://localhost:11434/api/tags
 ```
 
-Test Prompt:
+Test Prompt to ensure Ollama is working properly:
 
 ```bash
 curl -X POST http://localhost:11434/api/generate -H "Content-Type: application/json" -d \
@@ -218,6 +222,7 @@ The Docker configuration is optimized for Mac Mini M1 with <2GB RAM usage:
 - **Persistent storage**: Models are stored in a Docker volume
 
 Recommended models for low-memory usage:
+
 - `llama3.2:1b` (~1GB) - Best balance of performance and size
 - `gemma2:2b` (~1.4GB) - Good performance, slightly larger
 - `qwen2.5:1.5b` (~1.1GB) - Efficient alternative

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ This project was originally built for the [ModelVault take-home assignment](./AS
 
 - Node.js 18+
 - npm or yarn
+- Docker and Docker Compose (for local Ollama setup)
 
 ### Installation
 
@@ -73,6 +74,35 @@ Each log entry contains:
 - `timestamp`: ISO 8601 timestamp
 - `input`: The user's prompt
 - `output`: The generated response
+
+### Local AI Setup with Ollama (approx 15 min)
+
+Start the Ollama service using Docker:
+
+```bash
+# Start Ollama in the background
+docker-compose up -d
+
+# Pull a lightweight model (recommended for Mac Mini M1)
+docker exec -it offline-prompt-ollama ollama pull llama3.2:1b
+
+# Alternative models (choose one based on your needs):
+# docker exec -it offline-prompt-ollama ollama pull gemma2:2b  # 2GB model
+# docker exec -it offline-prompt-ollama ollama pull qwen2.5:1.5b  # 1.5GB model
+```
+
+Verify Ollama is running:
+
+```bash
+curl http://localhost:11434/api/tags
+```
+
+Test Prompt:
+
+```bash
+curl -X POST http://localhost:11434/api/generate -H "Content-Type: application/json" -d \
+'{"model": "llama3.2:1b", "prompt": "Say hi", "stream": false}'
+```
 
 ### Development
 
@@ -144,6 +174,8 @@ See `package.json` for complete list. Key commands:
 - `npm start` - Run production build
 - `npm run lint` - Code linting
 - `npm run format` - Code formatting
+- `docker-compose up -d` - Start Ollama service
+- `docker-compose down` - Stop Ollama service
 
 ## 🧪 Testing Strategy
 
@@ -169,10 +201,26 @@ The project uses Vitest for testing with:
 
 1. Clone or fork this repository
 2. Update `package.json` with your project details
-3. Modify the root endpoint in `src/api/root/` or create new API modules
-4. Add your business logic in the service layer
-5. Write tests in the `test/` directory
-6. Build and deploy
+3. Start Ollama with `docker-compose up -d` and pull a model
+4. Modify the root endpoint in `src/api/root/` or create new API modules
+5. Add your business logic in the service layer
+6. Write tests in the `test/` directory
+7. Build and deploy
+
+### Docker Setup Notes
+
+The Docker configuration is optimized for Mac Mini M1 with <2GB RAM usage:
+
+- **Memory limit**: 2GB max, 512MB reserved
+- **Single model loading**: Only one model loaded at a time
+- **Parallel processing**: Limited to 1 for memory efficiency
+- **Flash attention**: Enabled for better performance
+- **Persistent storage**: Models are stored in a Docker volume
+
+Recommended models for low-memory usage:
+- `llama3.2:1b` (~1GB) - Best balance of performance and size
+- `gemma2:2b` (~1.4GB) - Good performance, slightly larger
+- `qwen2.5:1.5b` (~1.1GB) - Efficient alternative
 
 This template provides a solid foundation for building modern, type-safe REST APIs with excellent developer experience.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  ollama:
+    image: ollama/ollama:latest
+    container_name: offline-prompt-ollama
+    ports:
+      - "11434:11434"
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
+    volumes:
+      - ollama_data:/root/.ollama
+    environment:
+      - OLLAMA_HOST=0.0.0.0:11434
+      - OLLAMA_MODELS=/root/.ollama/models
+      # Memory-optimized settings for Mac Mini M1
+      - OLLAMA_NUM_PARALLEL=1
+      - OLLAMA_MAX_LOADED_MODELS=1
+      - OLLAMA_FLASH_ATTENTION=1
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "ollama", "list"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+        reservations:
+          memory: 512M
+
+volumes:
+  ollama_data:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ollama/ollama:latest
     container_name: offline-prompt-ollama
     ports:
-      - "11434:11434"
+      - '11434:11434'
     dns:
       - 8.8.8.8
       - 8.8.4.4
@@ -18,7 +18,7 @@ services:
       - OLLAMA_FLASH_ATTENTION=1
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "ollama", "list"]
+      test: ['CMD', 'ollama', 'list']
       interval: 30s
       timeout: 10s
       retries: 3

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@zodios/core": "^10.9.6",
         "@zodios/express": "^10.6.1",
         "@zodios/openapi": "^10.5.0",
+        "dotenv": "^17.2.0",
         "express": "^4.21.2",
         "supertest": "^7.1.3",
         "swagger-ui-express": "^5.0.1",
@@ -2272,6 +2273,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
+      "integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@zodios/core": "^10.9.6",
     "@zodios/express": "^10.6.1",
     "@zodios/openapi": "^10.5.0",
+    "dotenv": "^17.2.0",
     "express": "^4.21.2",
     "supertest": "^7.1.3",
     "swagger-ui-express": "^5.0.1",

--- a/src/ai-models/ollama.service.ts
+++ b/src/ai-models/ollama.service.ts
@@ -1,0 +1,65 @@
+export interface OllamaResponse {
+  response: string;
+  model?: string;
+  created_at?: string;
+  done?: boolean;
+}
+
+export interface OllamaRequest {
+  model: string;
+  prompt: string;
+  stream?: boolean;
+}
+
+export class OllamaService {
+  private readonly baseUrl: string;
+  private readonly defaultModel: string;
+
+  constructor() {
+    this.baseUrl = process.env.OLLAMA_BASE_URL || '';
+    this.defaultModel = process.env.OLLAMA_MODEL || '';
+
+    if (!this.baseUrl) {
+      throw new Error('OLLAMA_BASE_URL environment variable is required');
+    }
+
+    if (!this.defaultModel) {
+      throw new Error('OLLAMA_MODEL environment variable is required');
+    }
+  }
+
+  async generateResponse(prompt: string, model?: string): Promise<string> {
+    const requestBody: OllamaRequest = {
+      model: model || this.defaultModel,
+      prompt,
+      stream: false
+    };
+
+    try {
+      const response = await fetch(`${this.baseUrl}/api/generate`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(requestBody)
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama API error: ${response.status} ${response.statusText}`);
+      }
+
+      const data = (await response.json()) as OllamaResponse;
+
+      if (!data.response) {
+        throw new Error('No response received from Ollama');
+      }
+
+      return data.response;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Failed to generate response from Ollama: ${error.message}`);
+      }
+      throw new Error('Failed to generate response from Ollama: Unknown error');
+    }
+  }
+}

--- a/src/api/generate/generate.contract.ts
+++ b/src/api/generate/generate.contract.ts
@@ -2,7 +2,19 @@ import { z } from 'zod';
 import { makeApi } from '@zodios/core';
 
 const generateRequestSchema = z.object({
-  prompt: z.string().min(1, 'Prompt must not be empty')
+  prompt: z
+    .string({
+      required_error: 'Prompt is required',
+      invalid_type_error: 'Prompt must be a string'
+    })
+    .trim()
+    .min(1, 'Prompt must not be empty'),
+  canned: z
+    .boolean({
+      invalid_type_error: 'Canned must be a boolean'
+    })
+    .optional()
+    .default(false)
 });
 
 const generateResponseSchema = z.object({
@@ -17,8 +29,8 @@ export const generateApi = makeApi([
   {
     method: 'post',
     path: '/generate',
-    description: 'Generate static AI response for given prompt',
-    summary: 'Generate static AI response for given prompt',
+    description: 'Generate AI response for given prompt (canned or from Ollama)',
+    summary: 'Generate AI response for given prompt (canned or from Ollama)',
     requestFormat: 'json',
     parameters: [
       {
@@ -37,6 +49,9 @@ export const generateApi = makeApi([
     ]
   }
 ]);
+
+// Export schemas for use in controllers
+export { generateRequestSchema, generateResponseSchema, errorResponseSchema };
 
 export type GenerateRequest = z.infer<typeof generateRequestSchema>;
 export type GenerateResponse = z.infer<typeof generateResponseSchema>;

--- a/src/api/generate/generate.controller.ts
+++ b/src/api/generate/generate.controller.ts
@@ -9,24 +9,11 @@ export class GenerateController {
     this.generateService = new GenerateService();
   }
 
-  generate = (req: Request, res: Response) => {
+  generate = async (req: Request, res: Response) => {
     try {
-      // Validate request body
-      const body = req.body as Partial<GenerateRequest>;
-
-      if (!body.prompt) {
-        return res.status(400).json({ error: 'Prompt is required' });
-      }
-
-      if (typeof body.prompt !== 'string') {
-        return res.status(400).json({ error: 'Prompt must be a string' });
-      }
-
-      if (body.prompt.trim().length === 0) {
-        return res.status(400).json({ error: 'Prompt must not be empty' });
-      }
-
-      const response = this.generateService.generateResponse({ prompt: body.prompt });
+      // req.body is already validated by Zodios middleware
+      const validatedBody = req.body as GenerateRequest;
+      const response = await this.generateService.generateResponse(validatedBody);
       res.json(response);
     } catch (error) {
       // eslint-disable-next-line no-console

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,9 @@
 import express from 'express';
 import swaggerUi from 'swagger-ui-express';
+import { zodiosApp } from '@zodios/express';
 import { RootController } from '@src/api/root/root.controller';
 import { GenerateController } from '@src/api/generate/generate.controller';
+import { generateApi } from '@src/api/generate/generate.contract';
 import { createOpenApiSpec } from '@src/openapi';
 
 export function createApp() {
@@ -12,8 +14,13 @@ export function createApp() {
   const rootController = new RootController();
   const generateController = new GenerateController();
 
+  // Use manual routing for root endpoint
   app.get('/', rootController.getRoot);
-  app.post('/generate', generateController.generate);
+
+  // Use Zodios for automatic validation
+  const generateApp = zodiosApp(generateApi);
+  generateApp.post('/generate', generateController.generate);
+  app.use(generateApp);
 
   const openApiSpec = createOpenApiSpec();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+import 'dotenv/config';
 import { createApp } from '@src/app';
 
 const PORT = process.env.PORT || 3000;

--- a/test/api/generate/generate.contract.test.ts
+++ b/test/api/generate/generate.contract.test.ts
@@ -1,0 +1,238 @@
+import request, { Response } from 'supertest';
+import { createApp } from '@src/app';
+import { describe, expect, test } from 'vitest';
+
+// Helper to check Zodios validation error format
+const expectValidationError = (response: Response, expectedMessage: string) => {
+  expect(response.body).toHaveProperty('error');
+  expect(Array.isArray(response.body.error)).toBe(true);
+  expect(response.body.error[0]).toHaveProperty('message', expectedMessage);
+};
+
+describe('POST /generate - Validation Tests', () => {
+  test('should return 400 for completely missing body', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').expect(400);
+
+    expectValidationError(response, 'Prompt is required');
+  });
+
+  test('should return 400 for empty object body', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({}).expect(400);
+
+    expectValidationError(response, 'Prompt is required');
+  });
+
+  test('should return 400 for null prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: null }).expect(400);
+
+    expectValidationError(response, 'Prompt must be a string');
+  });
+
+  test('should return 400 for undefined prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: undefined }).expect(400);
+
+    expectValidationError(response, 'Prompt is required');
+  });
+
+  test('should return 400 for number prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 123 }).expect(400);
+
+    expectValidationError(response, 'Prompt must be a string');
+  });
+
+  test('should return 400 for boolean prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: true }).expect(400);
+
+    expectValidationError(response, 'Prompt must be a string');
+  });
+
+  test('should return 400 for array prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/generate')
+      .send({ prompt: ['hello'] })
+      .expect(400);
+
+    expectValidationError(response, 'Prompt must be a string');
+  });
+
+  test('should return 400 for object prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/generate')
+      .send({ prompt: { text: 'hello' } })
+      .expect(400);
+
+    expectValidationError(response, 'Prompt must be a string');
+  });
+
+  test('should return 400 for empty string prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: '' }).expect(400);
+
+    expectValidationError(response, 'Prompt must not be empty');
+  });
+
+  test('should return 400 for whitespace-only prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: '   ' }).expect(400);
+
+    expectValidationError(response, 'Prompt must not be empty');
+  });
+
+  test('should return 400 for tab-only prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: '\t\t' }).expect(400);
+
+    expectValidationError(response, 'Prompt must not be empty');
+  });
+
+  test('should return 400 for newline-only prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: '\n\n' }).expect(400);
+
+    expectValidationError(response, 'Prompt must not be empty');
+  });
+
+  test('should return 400 for mixed whitespace prompt', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: ' \t\n ' }).expect(400);
+
+    expectValidationError(response, 'Prompt must not be empty');
+  });
+
+  test('should return 400 for string canned value', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 'test', canned: 'true' }).expect(400);
+
+    expectValidationError(response, 'Canned must be a boolean');
+  });
+
+  test('should return 400 for number canned value', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 'test', canned: 1 }).expect(400);
+
+    expectValidationError(response, 'Canned must be a boolean');
+  });
+
+  test('should return 400 for null canned value', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 'test', canned: null }).expect(400);
+
+    expectValidationError(response, 'Canned must be a boolean');
+  });
+
+  test('should return 400 for array canned value', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 'test', canned: [] }).expect(400);
+
+    expectValidationError(response, 'Canned must be a boolean');
+  });
+
+  test('should return 400 for object canned value', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/generate')
+      .send({ prompt: 'test', canned: { value: true } })
+      .expect(400);
+
+    expectValidationError(response, 'Canned must be a boolean');
+  });
+
+  test('should accept valid prompt with canned: true', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 'test prompt', canned: true }).expect(200);
+
+    expect(response.body).toHaveProperty('response');
+    expect(typeof response.body.response).toBe('string');
+  });
+
+  test('should accept valid prompt with canned: false', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 'test prompt', canned: false }).expect(200);
+
+    expect(response.body).toHaveProperty('response');
+    expect(typeof response.body.response).toBe('string');
+  }, 10000);
+
+  test('should accept valid prompt without canned property', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: 'test prompt' }).expect(200);
+
+    expect(response.body).toHaveProperty('response');
+    expect(typeof response.body.response).toBe('string');
+  }, 10000);
+
+  test('should accept prompt with leading/trailing whitespace (gets trimmed)', async () => {
+    const app = createApp();
+
+    const response = await request(app).post('/generate').send({ prompt: '  valid prompt  ' }).expect(200);
+
+    expect(response.body).toHaveProperty('response');
+    expect(typeof response.body.response).toBe('string');
+  }, 10000);
+
+  test('should handle very long prompt', async () => {
+    const app = createApp();
+    const longPrompt = 'a'.repeat(10000);
+
+    const response = await request(app).post('/generate').send({ prompt: longPrompt, canned: true }).expect(200);
+
+    expect(response.body).toHaveProperty('response');
+    expect(typeof response.body.response).toBe('string');
+  });
+
+  test('should handle special characters in prompt', async () => {
+    const app = createApp();
+    const specialPrompt = '!@#$%^&*(){}[]|\\:";\'<>?,./ 中文 русский 🎉';
+
+    const response = await request(app).post('/generate').send({ prompt: specialPrompt, canned: true }).expect(200);
+
+    expect(response.body).toHaveProperty('response');
+    expect(typeof response.body.response).toBe('string');
+  });
+
+  test('should ignore extra properties in request body', async () => {
+    const app = createApp();
+
+    const response = await request(app)
+      .post('/generate')
+      .send({
+        prompt: 'test prompt',
+        canned: true,
+        extraProperty: 'should be ignored',
+        anotherExtra: 123
+      })
+      .expect(200);
+
+    expect(response.body).toHaveProperty('response');
+    expect(typeof response.body.response).toBe('string');
+  });
+});

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,0 +1,7 @@
+// Test setup file - runs before all tests
+// This ensures environment variables are properly configured for testing
+
+import path from 'path';
+import dotenv from 'dotenv';
+
+dotenv.config({ path: path.join(__dirname, '..', '.env') });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,8 @@ import { resolve } from 'path';
 export default defineConfig({
   test: {
     include: ['test/**/*.test.ts'],
-    environment: 'node'
+    environment: 'node',
+    setupFiles: ['./test/setup.ts']
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- Add Ollama service for real AI model inference via Docker
- Implement canned response toggle (`canned: true/false`) for testing flexibility
- Add environment configuration for Ollama settings
- Configure Docker Compose with memory-optimized settings for Mac Mini M1
- Update validation to use native Zodios automatic validation

## Key Features

### 🤖 **Ollama AI Integration**
- New `OllamaService` class for communicating with local Ollama models
- Configurable via environment variables (`OLLAMA_BASE_URL`, `OLLAMA_MODEL`)
- Fallback to canned response if Ollama is unavailable

### 🔄 **Canned Response Toggle**
- New optional `canned` parameter in POST body
- `canned: true` returns predictable test response
- `canned: false` (default) uses real Ollama model

### 🐳 **Docker Setup**
- Memory-optimized Docker Compose configuration for Mac Mini M1
- Automatic DNS resolution and port mapping
- Health checks for reliable service startup

### ✅ **Enhanced Validation** 
- Replaced manual validation with native Zodios automatic validation
- Zero validation code in controllers - Zodios middleware handles everything
- Comprehensive validation tests with detailed error responses

## Test Plan

- [x] All 39 tests pass
- [x] Canned responses work correctly
- [x] Real Ollama integration works when service is running
- [x] Environment variable validation
- [x] Docker setup functional
- [x] Build passes

## Environment Setup

```bash
# Copy environment template
cp .env.example .env

# Start Ollama service
docker-compose up -d

# Pull recommended model
docker exec -it offline-prompt-ollama ollama pull llama3.2:1b
```

🤖 Generated with [Claude Code](https://claude.ai/code)